### PR TITLE
Chore: add extensions and large blob support

### DIFF
--- a/src/credential.ts
+++ b/src/credential.ts
@@ -92,6 +92,10 @@ export type GetCredentialCreationOptionsParameters = {
    */
   excludeCredentialIds?: readonly string[] | undefined
   /**
+   * List of Web Authentication API credentials to use during creation or authentication.
+   */
+  extensions?: PublicKeyCredentialCreationOptions['extensions'] | undefined
+  /**
    * An object describing the relying party that requested the credential creation
    */
   rp?:
@@ -151,6 +155,7 @@ export function getCredentialCreationOptions(
       name: window.document.title,
     },
     user,
+    extensions
   } = parameters
   const name = (user?.name ?? name_)!
   return {
@@ -178,6 +183,7 @@ export function getCredentialCreationOptions(
         name,
         displayName: user?.displayName ?? name,
       },
+      extensions
     },
   } as CredentialCreationOptions
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,9 @@ type CredentialMediationRequirement =
 type PublicKeyCredentialType = 'public-key'
 type ResidentKeyRequirement = 'discouraged' | 'preferred' | 'required'
 type UserVerificationRequirement = 'discouraged' | 'preferred' | 'required'
-
+type LargeBlobSupport = {
+  support: 'required' | 'preferred';
+};
 type BufferSource = ArrayBufferView | ArrayBuffer
 
 interface AuthenticationExtensionsClientInputs {
@@ -78,6 +80,7 @@ interface AuthenticationExtensionsClientInputs {
   credProps?: boolean
   hmacCreateSecret?: boolean
   minPinLength?: boolean
+  largeBlob?: LargeBlobSupport
 }
 
 interface AuthenticatorSelectionCriteria {


### PR DESCRIPTION
This PR is to add the ability to use `extensions` when creating a credential. I'm adding this specifically for the use of largeBlob support in my case, but it will also support the other extension types you've already included too. 

https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#largeblob