### PR TITLE
Chore: add prf extension type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -72,12 +72,19 @@ type ResidentKeyRequirement = 'discouraged' | 'preferred' | 'required'
 type UserVerificationRequirement = 'discouraged' | 'preferred' | 'required'
 
 type BufferSource = ArrayBufferView | ArrayBuffer
-
+type PrfExtension = {
+  prf: {
+    eval: {
+      first: Uint8Array;
+    };
+  };
+};
 interface AuthenticationExtensionsClientInputs {
   appid?: string
   credProps?: boolean
   hmacCreateSecret?: boolean
   minPinLength?: boolean
+  prf?: PrfExtension
 }
 
 interface AuthenticatorSelectionCriteria {


### PR DESCRIPTION
This adds the PRF extension type from the w3c reference here: https://github.com/w3c/webauthn/wiki/Explainer:-PRF-extension.

This is meant to follow on this [PR](https://github.com/wevm/webauthn-p256/pull/8) which adds the ability to pass in extensions in the `createCredential` function. 
